### PR TITLE
[RP-1729] Added single quotes to valid_filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres roughly to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - For dropdown button items, the behaviour can now be `:remote` as well
+- Added single quotes to the list of chars that gets rejected by the `:valid_filename` regex.
 ### Changed
 ### Fixed
 

--- a/developer_documentation/field_renderers.adoc
+++ b/developer_documentation/field_renderers.adoc
@@ -123,7 +123,7 @@ a|
 |Pattern to restrict input in the browser. (See `:pattern_msg` below for setting the input's `title`)
 a|
 * :no_spaces (user cannot type in a space)
-* :valid_filename (user cannot type in characters that are problematic in file names - _spaces, /, \, *, ?, :, &, ", <, >, pipechar_)
+* :valid_filename (user cannot type in characters that are problematic in file names - _spaces, /, \, *, ?, :, &, ", ', <, >, pipechar_)
 * :lowercase_underscore (can only type underscore or lowercase)
 * :alphanumeric (can only type alphanumeric characters: A-Z, a-z, 0-9)
 * :ipv4_address (user must enter a valid 1pv4 address)

--- a/lib/crossbeams/layout/renderer/input.rb
+++ b/lib/crossbeams/layout/renderer/input.rb
@@ -125,7 +125,7 @@ module Crossbeams
 
         PATTERN_REGEX = {
           no_spaces: '[^\s]+',
-          valid_filename: '[^\s\/\\\*?:&amp;&quot;<>\|]+',
+          valid_filename: '[^\s\/\\\*?:&amp;&quot;&apos;<>\|]+',
           lowercase_underscore: '[a-z_]*',
           alphanumeric: '[a-zA-Z0-9]*',
           ipv4_address: '(?:(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])(\.(?!$)|$)){4}'
@@ -133,7 +133,7 @@ module Crossbeams
 
         PATTERN_TITLES = {
           no_spaces: 'no spaces allowed',
-          valid_filename: 'no spaces, asterisks, question marks, greater-than or less-than signs, colons, pipes, quotes, ampersands or slashes allowed',
+          valid_filename: 'no spaces, asterisks, question marks, greater-than or less-than signs, colons, pipes, quotes, apostrophes, ampersands or slashes allowed',
           lowercase_underscore: 'only alphabetic characters and underscore (_) allowed',
           alphanumeric: 'only alphanumeric characters allowed (a-z and 0-9)',
           ipv4_address: 'must be a valid IP v4 address'

--- a/test/crossbeams/input_test.rb
+++ b/test/crossbeams/input_test.rb
@@ -61,7 +61,7 @@ class Crossbeams::InputTest < Minitest::Test
     assert_equal '[^\s]+', html_element_attribute_value(s, :input, :pattern)
 
     s = simple_input_render(:input, '123', pattern: :valid_filename)
-    assert_equal '[^\s\/\\\*?:&"<>\\|]+', html_element_attribute_value(s, :input, :pattern)
+    assert_equal '[^\s\/\\\*?:&"<>\\|\']+', html_element_attribute_value(s, :input, :pattern)
 
     s = simple_input_render(:input, '123', pattern: :lowercase_underscore)
     assert_equal '[a-z_]*', html_element_attribute_value(s, :input, :pattern)


### PR DESCRIPTION
[RP-1729](https://agrigate.atlassian.net/browse/RP-1729)

Added single quotes to the list of chars that gets rejected by the `valid_filename` regex.

[RP-1729]: https://agrigate.atlassian.net/browse/RP-1729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ